### PR TITLE
Use old message pointer class when using legacy attribute

### DIFF
--- a/src/sns_extended_client/session.py
+++ b/src/sns_extended_client/session.py
@@ -8,6 +8,7 @@ from .exceptions import SNSExtendedClientException, MissingPayloadOffloadingReso
 
 DEFAULT_MESSAGE_SIZE_THRESHOLD = 262144
 MESSAGE_POINTER_CLASS = "software.amazon.payloadoffloading.PayloadS3Pointer"
+LEGACY_MESSAGE_POINTER_CLASS = "com.amazon.sqs.javamessaging.MessageS3Pointer"
 LEGACY_RESERVED_ATTRIBUTE_NAME = "SQSLargePayloadSize"
 RESERVED_ATTRIBUTE_NAME = "ExtendedPayloadSize"
 S3_KEY_ATTRIBUTE_NAME = "S3Key"
@@ -176,6 +177,12 @@ def _make_payload(self, message_attributes: dict, message_body, message_structur
                     f"Message attribute name {attribute} is reserved for use by SNS extended client."
                 )
 
+        message_pointer_used = (
+            LEGACY_MESSAGE_POINTER_CLASS
+            if self.use_legacy_attribute
+            else MESSAGE_POINTER_CLASS
+        )
+
         attribute_name_used = (
             LEGACY_RESERVED_ATTRIBUTE_NAME
             if self.use_legacy_attribute
@@ -196,7 +203,7 @@ def _make_payload(self, message_attributes: dict, message_body, message_structur
 
         message_body = dumps(
             [
-                MESSAGE_POINTER_CLASS,
+                message_pointer_used,
                 {"s3BucketName": self.large_payload_support, "s3Key": s3_key},
             ]
         )

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -8,6 +8,7 @@ from json import JSONDecodeError, loads, dumps
 from src.sns_extended_client.session import (
     DEFAULT_MESSAGE_SIZE_THRESHOLD,
     MESSAGE_POINTER_CLASS,
+    LEGACY_MESSAGE_POINTER_CLASS,
     RESERVED_ATTRIBUTE_NAME,
     LEGACY_RESERVED_ATTRIBUTE_NAME,
     MAX_ALLOWED_ATTRIBUTES,
@@ -309,7 +310,7 @@ class TestSNSExtendedClient(unittest.TestCase):
         sns_extended_client = self.sns_extended_client
         sns_extended_client.use_legacy_attribute = True
 
-        actual_msg_attr, _ = sns_extended_client._make_payload(
+        actual_msg_attr, actual_msg_body = sns_extended_client._make_payload(
             SMALL_MSG_ATTRIBUTES, LARGE_MSG_BODY, None
         )
 
@@ -317,6 +318,7 @@ class TestSNSExtendedClient(unittest.TestCase):
             SMALL_MSG_ATTRIBUTES, LARGE_MSG_BODY, LEGACY_RESERVED_ATTRIBUTE_NAME
         )
 
+        self.assertEqual(loads(actual_msg_body)[0], LEGACY_MESSAGE_POINTER_CLASS)
         self.assertEqual(expected_msg_attr, actual_msg_attr)
 
     def test_make_payload_use_custom_S3_key(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the legacy message pointer class to be used when legacy attribute is being used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
