### PR TITLE
Use Poetry workflow to publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install Poetry
+        run: |
+          pip install poetry==1.4.0
+          poetry --version
+      - name: Check if there is a parent commit
+        id: check-parent-commit
+        run: |
+          echo "sha=$(git rev-parse --verify --quiet HEAD^)" >> $GITHUB_OUTPUT
+      - name: Detect and tag new version
+        id: check-version
+        if: steps.check-parent-commit.outputs.sha
+        uses: salsify/action-detect-and-tag-new-version@v2
+        with:
+          version-command: |
+            bash -o pipefail -c "poetry version | awk '{ print \$2 }'"
+      - name: Bump version for developmental release
+        if: "! steps.check-version.outputs.tag"
+        run: |
+          poetry version patch &&
+          version=$(poetry version | awk '{ print $2 }') &&
+          poetry version $version.dev.$(date +%s)
+      - name: Build package
+        run: |
+          poetry build
+      - name: Install package
+        run: |
+          poetry install
+      - name: Run pytest
+        run: |
+          poetry run pytest --cov=sns_extended_client test --cov-report term-missing
+      - name: Publish package on PyPI
+        if: steps.check-version.outputs.tag
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+      - name: Publish package on TestPyPI
+        if: "! steps.check-version.outputs.tag"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/poetry.lock
+++ b/poetry.lock
@@ -72,18 +72,18 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.26.91"
+version = "1.26.92"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.26.91-py3-none-any.whl", hash = "sha256:3ce2225a61832d69831d669d912424ea3863268ca1cfa2a82203bb90952acefa"},
-    {file = "boto3-1.26.91.tar.gz", hash = "sha256:278d896e9090a976f41ec68da5c572bc4e5b7cb1e515f1898fee8cb2fadfb50d"},
+    {file = "boto3-1.26.92-py3-none-any.whl", hash = "sha256:49bef90c0ccd6cd87a304d8563958d2d00f2361e02ec953fc3c8bde87cf21112"},
+    {file = "boto3-1.26.92.tar.gz", hash = "sha256:401088934097260597495ae3c1842a59a701712a2d0e89443f8ede9161cd3806"},
 ]
 
 [package.dependencies]
-botocore = ">=1.29.91,<1.30.0"
+botocore = ">=1.29.92,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -92,14 +92,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.29.91"
+version = "1.29.92"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.29.91-py3-none-any.whl", hash = "sha256:4ed6a488aee1b42367eace71f7d0993dda05b02eebd7dcdd78db5c9ce3d80da5"},
-    {file = "botocore-1.29.91.tar.gz", hash = "sha256:a8a800a2a945da807758cace539fc5b5ec1d5082ce363799d3a3870c2c4ed6fc"},
+    {file = "botocore-1.29.92-py3-none-any.whl", hash = "sha256:71a67c1f896db0204b97a8e199aa1188541d139ce3130ba52261ccd19b6e17db"},
+    {file = "botocore-1.29.92.tar.gz", hash = "sha256:0bb40ca410ad26c5e9821ab1ab52ea894759ed2188afd99152261c5e895d8c9c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,12 @@
 name = "amazon-sns-extended-client"
 version = "0.1.0"
 description = "Python version of AWS SNS extended client to publish large payload message"
-authors = ["Tianlu Shi <tianls@amazon.com>"]
+authors = ["Amazon Web Service - SNS"]
 license = "Apache-2.0"
 readme = "README.md"
 packages = [{include = "sns_extended_client", from="src"}]
+homepage = "https://github.com/awslabs/amazon-sns-python-extended-client-lib"
+repository = "https://github.com/awslabs/amazon-sns-python-extended-client-lib"
 classifiers=[
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
*Issue #, if available:*

Add this workflow as the CD for PyPI publish.

*Description of changes:*
* Add repo info and homepage in pyproject.toml
* Use Poetry GitHub action to handle the release of this package.
  * This workflow will only be triggered when there is a push to main branch.
  * About version control,  it will using [this action](https://github.com/marketplace/actions/detect-and-tag-new-version) to check the version defined in pyproject.toml.
    *  If there is a new version, it will publish to public PyPI by using the version in the config
    *  If the version number remains the same, it will do a version patch with epoch datetime and publish to TestPyPi. See test result: https://test.pypi.org/project/amazon-sns-extended-client/#history
    * I only create TOKEN for TEST PyPI for now. I will create the TOKEN for PyPI after we are done with AppSec review.

*Test:*
Tested in my local main branch: https://github.com/shih/amazon-sns-python-extended-client-lib/actions/workflows/release.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
