### PR TITLE
Change release procedure to use OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,15 @@ on:
     branches:
       - main
 
+env:
+  AWS_REGION: us-east-1
+
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v3
@@ -49,16 +53,32 @@ jobs:
       - name: Run pytest
         run: |
           poetry run pytest --cov=sns_extended_client test --cov-report term-missing
-      - name: Publish package on PyPI
-        if: steps.check-version.outputs.tag
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          role-to-assume: ${{ vars.OIDC_ROLE_NAME }}
+          role-session-name: publishrolesession
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Retrieve TEST PYPI TOKEN from secretsmanager
+        id: get-test-pypi-token
+        if: "! steps.check-version.outputs.tag"
+        run: |
+          echo "token=$(aws secretsmanager get-secret-value --secret-id ${{ vars.TEST_PYPI_TOKEN_NAME }} | jq -r '.SecretString')" >> $GITHUB_OUTPUT
+      - name: Retrieve PYPI TOKEN from secretsmanager
+        id: get-pypi-token
+        if: steps.check-version.outputs.tag
+        run: |
+          echo "token=$(aws secretsmanager get-secret-value --secret-id ${{ vars.PYPI_TOKEN_NAME }} | jq -r '.SecretString')" >> $GITHUB_OUTPUT
       - name: Publish package on TestPyPI
         if: "! steps.check-version.outputs.tag"
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          password: ${{ steps.get-test-pypi-token.outputs.token }}
           repository_url: https://test.pypi.org/legacy/
+      - name: Publish package on PyPI
+        if: steps.check-version.outputs.tag
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ steps.get-pypi-token.outputs.token }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To meet security compliance, we need to change our current release procedure which is using the PyPI token we stored in GH secrets and do poetry publish.

The new approach is:
1. We store our Tokens in SecretsManager in our AWS account
2. Configure GH Action to get our AWS account credential
3. Retrieve PyPI Token from SecretsManager
4. Poetry Publish


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
